### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/config/BiomeTweaker/scripts/water_color.cfg
+++ b/config/BiomeTweaker/scripts/water_color.cfg
@@ -1,7 +1,7 @@
 
 ###########################################################################
 # Water colors
-# Numbers are from https://minecraft.gamepedia.com/Water
+# Numbers are from https://minecraft.wiki/w/Water
 ###########################################################################
 
 ocean = forBiomes("minecraft:ocean")

--- a/config/RTG/biomes/biomesoplenty/alps.cfg
+++ b/config/RTG/biomes/biomesoplenty/alps.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/alps_foothills.cfg
+++ b/config/RTG/biomes/biomesoplenty/alps_foothills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/bamboo_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/bamboo_forest.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/bayou.cfg
+++ b/config/RTG/biomes/biomesoplenty/bayou.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/bog.cfg
+++ b/config/RTG/biomes/biomesoplenty/bog.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/boreal_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/boreal_forest.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/brushland.cfg
+++ b/config/RTG/biomes/biomesoplenty/brushland.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/chaparral.cfg
+++ b/config/RTG/biomes/biomesoplenty/chaparral.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/cherry_blossom_grove.cfg
+++ b/config/RTG/biomes/biomesoplenty/cherry_blossom_grove.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/cold_desert.cfg
+++ b/config/RTG/biomes/biomesoplenty/cold_desert.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/coniferous_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/coniferous_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/coral_reef.cfg
+++ b/config/RTG/biomes/biomesoplenty/coral_reef.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/crag.cfg
+++ b/config/RTG/biomes/biomesoplenty/crag.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -101,7 +101,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -110,7 +110,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/dead_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/dead_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/dead_swamp.cfg
+++ b/config/RTG/biomes/biomesoplenty/dead_swamp.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/eucalyptus_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/eucalyptus_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/fen.cfg
+++ b/config/RTG/biomes/biomesoplenty/fen.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/flower_field.cfg
+++ b/config/RTG/biomes/biomesoplenty/flower_field.cfg
@@ -46,7 +46,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/flower_island.cfg
+++ b/config/RTG/biomes/biomesoplenty/flower_island.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/glacier.cfg
+++ b/config/RTG/biomes/biomesoplenty/glacier.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/grassland.cfg
+++ b/config/RTG/biomes/biomesoplenty/grassland.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/gravel_beach.cfg
+++ b/config/RTG/biomes/biomesoplenty/gravel_beach.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -101,7 +101,7 @@ surfaces {
         # Set this to change this biome's mix filler block (the block underneath the mix block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Filler Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/grove.cfg
+++ b/config/RTG/biomes/biomesoplenty/grove.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/highland.cfg
+++ b/config/RTG/biomes/biomesoplenty/highland.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/kelp_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/kelp_forest.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/land_of_lakes.cfg
+++ b/config/RTG/biomes/biomesoplenty/land_of_lakes.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/lavender_fields.cfg
+++ b/config/RTG/biomes/biomesoplenty/lavender_fields.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/lush_desert.cfg
+++ b/config/RTG/biomes/biomesoplenty/lush_desert.cfg
@@ -56,7 +56,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -85,7 +85,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/lush_swamp.cfg
+++ b/config/RTG/biomes/biomesoplenty/lush_swamp.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/mangrove.cfg
+++ b/config/RTG/biomes/biomesoplenty/mangrove.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/maple_woods.cfg
+++ b/config/RTG/biomes/biomesoplenty/maple_woods.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/marsh.cfg
+++ b/config/RTG/biomes/biomesoplenty/marsh.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/meadow.cfg
+++ b/config/RTG/biomes/biomesoplenty/meadow.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/moor.cfg
+++ b/config/RTG/biomes/biomesoplenty/moor.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/mountain.cfg
+++ b/config/RTG/biomes/biomesoplenty/mountain.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/mountain_foothills.cfg
+++ b/config/RTG/biomes/biomesoplenty/mountain_foothills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/mystic_grove.cfg
+++ b/config/RTG/biomes/biomesoplenty/mystic_grove.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/oasis.cfg
+++ b/config/RTG/biomes/biomesoplenty/oasis.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/ominous_woods.cfg
+++ b/config/RTG/biomes/biomesoplenty/ominous_woods.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/orchard.cfg
+++ b/config/RTG/biomes/biomesoplenty/orchard.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/origin_beach.cfg
+++ b/config/RTG/biomes/biomesoplenty/origin_beach.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/origin_island.cfg
+++ b/config/RTG/biomes/biomesoplenty/origin_island.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/outback.cfg
+++ b/config/RTG/biomes/biomesoplenty/outback.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/overgrown_cliffs.cfg
+++ b/config/RTG/biomes/biomesoplenty/overgrown_cliffs.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/pasture.cfg
+++ b/config/RTG/biomes/biomesoplenty/pasture.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/prairie.cfg
+++ b/config/RTG/biomes/biomesoplenty/prairie.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/quagmire.cfg
+++ b/config/RTG/biomes/biomesoplenty/quagmire.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/rainforest.cfg
+++ b/config/RTG/biomes/biomesoplenty/rainforest.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/redwood_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/redwood_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/sacred_springs.cfg
+++ b/config/RTG/biomes/biomesoplenty/sacred_springs.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/seasonal_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/seasonal_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/shield.cfg
+++ b/config/RTG/biomes/biomesoplenty/shield.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/shrubland.cfg
+++ b/config/RTG/biomes/biomesoplenty/shrubland.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/snowy_coniferous_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/snowy_coniferous_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/snowy_forest.cfg
+++ b/config/RTG/biomes/biomesoplenty/snowy_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/steppe.cfg
+++ b/config/RTG/biomes/biomesoplenty/steppe.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/temperate_rainforest.cfg
+++ b/config/RTG/biomes/biomesoplenty/temperate_rainforest.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/tropical_island.cfg
+++ b/config/RTG/biomes/biomesoplenty/tropical_island.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/tropical_rainforest.cfg
+++ b/config/RTG/biomes/biomesoplenty/tropical_rainforest.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/tundra.cfg
+++ b/config/RTG/biomes/biomesoplenty/tundra.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/volcanic_island.cfg
+++ b/config/RTG/biomes/biomesoplenty/volcanic_island.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/wasteland.cfg
+++ b/config/RTG/biomes/biomesoplenty/wasteland.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/wetland.cfg
+++ b/config/RTG/biomes/biomesoplenty/wetland.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/white_beach.cfg
+++ b/config/RTG/biomes/biomesoplenty/white_beach.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/woodland.cfg
+++ b/config/RTG/biomes/biomesoplenty/woodland.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/biomesoplenty/xeric_shrubland.cfg
+++ b/config/RTG/biomes/biomesoplenty/xeric_shrubland.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/beaches.cfg
+++ b/config/RTG/biomes/minecraft/beaches.cfg
@@ -46,7 +46,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -106,7 +106,7 @@ surfaces {
         # Set this to change this biome's mix filler block (the block underneath the mix block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Filler Block ID"=
     }

--- a/config/RTG/biomes/minecraft/birch_forest.cfg
+++ b/config/RTG/biomes/minecraft/birch_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/birch_forest_hills.cfg
+++ b/config/RTG/biomes/minecraft/birch_forest_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/cold_beach.cfg
+++ b/config/RTG/biomes/minecraft/cold_beach.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -101,7 +101,7 @@ surfaces {
         # Set this to change this biome's mix filler block (the block underneath the mix block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Filler Block ID"=
     }

--- a/config/RTG/biomes/minecraft/deep_ocean.cfg
+++ b/config/RTG/biomes/minecraft/deep_ocean.cfg
@@ -46,7 +46,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -106,7 +106,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/desert.cfg
+++ b/config/RTG/biomes/minecraft/desert.cfg
@@ -46,7 +46,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: minecraft:sandstone]
         S:"Filler Block ID"=minecraft:sandstone
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/desert_hills.cfg
+++ b/config/RTG/biomes/minecraft/desert_hills.cfg
@@ -46,7 +46,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/extreme_hills.cfg
+++ b/config/RTG/biomes/minecraft/extreme_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -120,7 +120,7 @@ surfaces {
         # Set this to change this biome's mix filler block (the block underneath the mix block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Filler Block ID"=
     }

--- a/config/RTG/biomes/minecraft/extreme_hills_with_trees.cfg
+++ b/config/RTG/biomes/minecraft/extreme_hills_with_trees.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/forest.cfg
+++ b/config/RTG/biomes/minecraft/forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -120,7 +120,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }

--- a/config/RTG/biomes/minecraft/forest_hills.cfg
+++ b/config/RTG/biomes/minecraft/forest_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -120,7 +120,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }

--- a/config/RTG/biomes/minecraft/frozen_ocean.cfg
+++ b/config/RTG/biomes/minecraft/frozen_ocean.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -101,7 +101,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/frozen_river.cfg
+++ b/config/RTG/biomes/minecraft/frozen_river.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/ice_flats.cfg
+++ b/config/RTG/biomes/minecraft/ice_flats.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/ice_mountains.cfg
+++ b/config/RTG/biomes/minecraft/ice_mountains.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -106,7 +106,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -115,7 +115,7 @@ surfaces {
         # Set this to change this biome's mix filler block (the block underneath the mix block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Filler Block ID"=
     }

--- a/config/RTG/biomes/minecraft/jungle.cfg
+++ b/config/RTG/biomes/minecraft/jungle.cfg
@@ -56,7 +56,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -85,7 +85,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -116,7 +116,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/jungle_edge.cfg
+++ b/config/RTG/biomes/minecraft/jungle_edge.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/jungle_hills.cfg
+++ b/config/RTG/biomes/minecraft/jungle_hills.cfg
@@ -56,7 +56,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -85,7 +85,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mesa.cfg
+++ b/config/RTG/biomes/minecraft/mesa.cfg
@@ -40,7 +40,7 @@ decorations {
     # A list of block states to use for this biome's plateau gradients.
     # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
     # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-    # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+    # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
     S:"Plateaus.Gradient Blocks" <
         minecraft:stained_hardened_clay[color=yellow]
         minecraft:stained_hardened_clay[color=yellow]
@@ -95,7 +95,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -104,7 +104,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -114,7 +114,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -124,7 +124,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -155,7 +155,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -164,7 +164,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mesa_clear_rock.cfg
+++ b/config/RTG/biomes/minecraft/mesa_clear_rock.cfg
@@ -40,7 +40,7 @@ decorations {
     # A list of block states to use for this biome's plateau gradients.
     # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
     # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-    # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+    # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
     S:"Plateaus.Gradient Blocks" <
         minecraft:stained_hardened_clay[color=yellow]
         minecraft:stained_hardened_clay[color=yellow]
@@ -95,7 +95,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -104,7 +104,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -114,7 +114,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -124,7 +124,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -155,7 +155,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -164,7 +164,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mesa_rock.cfg
+++ b/config/RTG/biomes/minecraft/mesa_rock.cfg
@@ -40,7 +40,7 @@ decorations {
     # A list of block states to use for this biome's plateau gradients.
     # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
     # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-    # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+    # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
     S:"Plateaus.Gradient Blocks" <
         minecraft:stained_hardened_clay[color=yellow]
         minecraft:stained_hardened_clay[color=yellow]
@@ -95,7 +95,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -104,7 +104,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -114,7 +114,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -124,7 +124,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -155,7 +155,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -164,7 +164,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }
@@ -173,7 +173,7 @@ surfaces {
         # Set this to change this biome's 3rd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 3 Block ID"=
     }
@@ -182,7 +182,7 @@ surfaces {
         # Set this to change this biome's 4th mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 4 Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mushroom_island.cfg
+++ b/config/RTG/biomes/minecraft/mushroom_island.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mushroom_island_shore.cfg
+++ b/config/RTG/biomes/minecraft/mushroom_island_shore.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_birch_forest.cfg
+++ b/config/RTG/biomes/minecraft/mutated_birch_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_birch_forest_hills.cfg
+++ b/config/RTG/biomes/minecraft/mutated_birch_forest_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_desert.cfg
+++ b/config/RTG/biomes/minecraft/mutated_desert.cfg
@@ -46,7 +46,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_extreme_hills.cfg
+++ b/config/RTG/biomes/minecraft/mutated_extreme_hills.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -101,7 +101,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -110,7 +110,7 @@ surfaces {
         # Set this to change this biome's mix filler block (the block underneath the mix block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Filler Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_extreme_hills_with_trees.cfg
+++ b/config/RTG/biomes/minecraft/mutated_extreme_hills_with_trees.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -101,7 +101,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_forest.cfg
+++ b/config/RTG/biomes/minecraft/mutated_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_ice_flats.cfg
+++ b/config/RTG/biomes/minecraft/mutated_ice_flats.cfg
@@ -46,7 +46,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_jungle.cfg
+++ b/config/RTG/biomes/minecraft/mutated_jungle.cfg
@@ -56,7 +56,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -85,7 +85,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_jungle_edge.cfg
+++ b/config/RTG/biomes/minecraft/mutated_jungle_edge.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_mesa.cfg
+++ b/config/RTG/biomes/minecraft/mutated_mesa.cfg
@@ -40,7 +40,7 @@ decorations {
     # A list of block states to use for this biome's plateau gradients.
     # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
     # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-    # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+    # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
     S:"Plateaus.Gradient Blocks" <
         minecraft:stained_hardened_clay[color=yellow]
         minecraft:stained_hardened_clay[color=yellow]
@@ -95,7 +95,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -104,7 +104,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -114,7 +114,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -124,7 +124,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -155,7 +155,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -164,7 +164,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_mesa_clear_rock.cfg
+++ b/config/RTG/biomes/minecraft/mutated_mesa_clear_rock.cfg
@@ -40,7 +40,7 @@ decorations {
     # A list of block states to use for this biome's plateau gradients.
     # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
     # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-    # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+    # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
     S:"Plateaus.Gradient Blocks" <
         minecraft:stained_hardened_clay[color=yellow]
         minecraft:stained_hardened_clay[color=yellow]
@@ -95,7 +95,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -104,7 +104,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -114,7 +114,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -124,7 +124,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -155,7 +155,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -164,7 +164,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_mesa_rock.cfg
+++ b/config/RTG/biomes/minecraft/mutated_mesa_rock.cfg
@@ -40,7 +40,7 @@ decorations {
     # A list of block states to use for this biome's plateau gradients.
     # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
     # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-    # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+    # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
     S:"Plateaus.Gradient Blocks" <
         minecraft:stained_hardened_clay[color=yellow]
         minecraft:stained_hardened_clay[color=yellow]
@@ -95,7 +95,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -104,7 +104,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -114,7 +114,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -124,7 +124,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -155,7 +155,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -164,7 +164,7 @@ surfaces {
         # Set this to change this biome's 2nd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 2 Block ID"=
     }
@@ -173,7 +173,7 @@ surfaces {
         # Set this to change this biome's 3rd mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 3 Block ID"=
     }
@@ -182,7 +182,7 @@ surfaces {
         # Set this to change this biome's 4th mix block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix 4 Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_plains.cfg
+++ b/config/RTG/biomes/minecraft/mutated_plains.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_redwood_taiga.cfg
+++ b/config/RTG/biomes/minecraft/mutated_redwood_taiga.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_redwood_taiga_hills.cfg
+++ b/config/RTG/biomes/minecraft/mutated_redwood_taiga_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_roofed_forest.cfg
+++ b/config/RTG/biomes/minecraft/mutated_roofed_forest.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_savanna.cfg
+++ b/config/RTG/biomes/minecraft/mutated_savanna.cfg
@@ -56,7 +56,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -85,7 +85,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -116,7 +116,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_savanna_rock.cfg
+++ b/config/RTG/biomes/minecraft/mutated_savanna_rock.cfg
@@ -40,7 +40,7 @@ decorations {
     # A list of block states to use for this biome's plateau gradients.
     # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
     # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-    # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+    # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
     S:"Plateaus.Gradient Blocks" <
         minecraft:stained_hardened_clay[color=white]
         minecraft:stained_hardened_clay[color=white]
@@ -83,7 +83,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -92,7 +92,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -102,7 +102,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -112,7 +112,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -143,7 +143,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_swampland.cfg
+++ b/config/RTG/biomes/minecraft/mutated_swampland.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_taiga.cfg
+++ b/config/RTG/biomes/minecraft/mutated_taiga.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/mutated_taiga_cold.cfg
+++ b/config/RTG/biomes/minecraft/mutated_taiga_cold.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/ocean.cfg
+++ b/config/RTG/biomes/minecraft/ocean.cfg
@@ -46,7 +46,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -106,7 +106,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/plains.cfg
+++ b/config/RTG/biomes/minecraft/plains.cfg
@@ -55,7 +55,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -64,7 +64,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -74,7 +74,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -84,7 +84,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/redwood_taiga.cfg
+++ b/config/RTG/biomes/minecraft/redwood_taiga.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/redwood_taiga_hills.cfg
+++ b/config/RTG/biomes/minecraft/redwood_taiga_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/river.cfg
+++ b/config/RTG/biomes/minecraft/river.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/roofed_forest.cfg
+++ b/config/RTG/biomes/minecraft/roofed_forest.cfg
@@ -56,7 +56,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -85,7 +85,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -116,7 +116,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/savanna.cfg
+++ b/config/RTG/biomes/minecraft/savanna.cfg
@@ -56,7 +56,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -65,7 +65,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -75,7 +75,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -85,7 +85,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -116,7 +116,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/savanna_rock.cfg
+++ b/config/RTG/biomes/minecraft/savanna_rock.cfg
@@ -40,7 +40,7 @@ decorations {
     # A list of block states to use for this biome's plateau gradients.
     # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
     # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-    # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+    # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
     S:"Plateaus.Gradient Blocks" <
         minecraft:stained_hardened_clay[color=white]
         minecraft:stained_hardened_clay[color=white]
@@ -83,7 +83,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -92,7 +92,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -102,7 +102,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -112,7 +112,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -143,7 +143,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/smaller_extreme_hills.cfg
+++ b/config/RTG/biomes/minecraft/smaller_extreme_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }
@@ -120,7 +120,7 @@ surfaces {
         # Set this to change this biome's mix filler block (the block underneath the mix block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Filler Block ID"=
     }

--- a/config/RTG/biomes/minecraft/stone_beach.cfg
+++ b/config/RTG/biomes/minecraft/stone_beach.cfg
@@ -41,7 +41,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -50,7 +50,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -101,7 +101,7 @@ surfaces {
         # Set this to change this biome's mix filler block (the block underneath the mix block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Filler Block ID"=
     }

--- a/config/RTG/biomes/minecraft/swampland.cfg
+++ b/config/RTG/biomes/minecraft/swampland.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/taiga.cfg
+++ b/config/RTG/biomes/minecraft/taiga.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/biomes/minecraft/taiga_cold.cfg
+++ b/config/RTG/biomes/minecraft/taiga_cold.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/taiga_cold_hills.cfg
+++ b/config/RTG/biomes/minecraft/taiga_cold_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }

--- a/config/RTG/biomes/minecraft/taiga_hills.cfg
+++ b/config/RTG/biomes/minecraft/taiga_hills.cfg
@@ -51,7 +51,7 @@ surfaces {
         # Set this to change this biome's top block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Top Block ID"=
     }
@@ -60,7 +60,7 @@ surfaces {
         # Set this to change this biome's filler block (the block underneath the top block).
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Filler Block ID"=
     }
@@ -70,7 +70,7 @@ surfaces {
         # Set this to change this biome's cliff stone block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Stone Block ID"=
     }
@@ -80,7 +80,7 @@ surfaces {
         # Set this to change this biome's cliff cobble block.
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Cliff Cobble Block ID"=
     }
@@ -111,7 +111,7 @@ surfaces {
         # Set this to change this biome's mix block
         # Syntax : <ResourceLocation> [<IProperty name> = <value>, <IProperty name> = <value>, ...]
         # Example: minecraft:stone[variant=diorite], or minecraft:stained_glass_pane[color=pink,north=true,east=false,south=true,west=false]
-        # For a list of property names and values, see: https://minecraft.gamepedia.com/Block_states
+        # For a list of property names and values, see: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [default: ]
         S:"Mix Block ID"=
     }

--- a/config/RTG/rtg.cfg
+++ b/config/RTG/rtg.cfg
@@ -55,7 +55,7 @@ common {
 
     trees {
         # Set this to FALSE to prevent the trunks of RTG trees from using the 'all-bark' texture model.
-        # For more information, visit http://minecraft.gamepedia.com/Wood#Block_data
+        # For more information, visit http://minecraft.wiki/w/Wood#Block_data
         B:barkCoveredLogs=true
 
         # 1/x chance that a vanilla sapling will grow one of RTG's custom trees.

--- a/config/bettercombat.cfg
+++ b/config/bettercombat.cfg
@@ -112,7 +112,7 @@ bows {
     # Setting [Ticks] to 20 would Float the amount of time it takes to fully draw back a vanilla bow.
     # Setting [Ticks] to -10 would reduce the amount of time it takes to fully draw back a vanilla bow by half.
     # 
-    # More info on bows can be found here   ->   https://minecraft.fandom.com/wiki/Bow#Weapon [default: [[Bow=minecraft:bow]	[Damage Multiplier=1.00]	[Velocity=0.90]	[Ticks=0]]]
+    # More info on bows can be found here   ->   https://minecraft.wiki/w/Bow#Weapon [default: [[Bow=minecraft:bow]	[Damage Multiplier=1.00]	[Velocity=0.90]	[Ticks=0]]]
     S:"Bow Tweaker" <
         [Bow=minecraft:bow]	[Damage Multiplier=1.00]	[Velocity=0.90]	[Ticks=0]
      >

--- a/config/pyrotech/module.tech.Basic.cfg
+++ b/config/pyrotech/module.tech.Basic.cfg
@@ -1039,7 +1039,7 @@ general {
         # The time of day that the campfire effects should start working.
         # If the current world time is larger than this value and less than
         # the stop value, the effects will work.
-        # See: https://minecraft.gamepedia.com/Day-night_cycle#24-hour_Minecraft_day
+        # See: https://minecraft.wiki/w/Day-night_cycle#24-hour_Minecraft_day
         # Default: 12000
         # Min: 0
         # Max: 24000
@@ -1048,7 +1048,7 @@ general {
         # The time of day that the campfire effects should stop working.
         # If the current world time is less than this value and larger than
         # the start value, the effect will work.
-        # See: https://minecraft.gamepedia.com/Day-night_cycle#24-hour_Minecraft_day
+        # See: https://minecraft.wiki/w/Day-night_cycle#24-hour_Minecraft_day
         # Default: 23000
         # Min: 0
         # Max: 24000

--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -3128,7 +3128,7 @@ world {
         # <id>,<level>,<min_price>,<max_price>,<color>,<name>
         # 
         # With the following descriptions:
-        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
         #  - <level> being the Cartographer villager level required for the map to be unlockable
         #  - <min_price> being the cheapest (in Emeralds) the map can be
         #  - <max_price> being the most expensive (in Emeralds) the map can be

--- a/oresources/rtg/lang/en_us.lang
+++ b/oresources/rtg/lang/en_us.lang
@@ -308,4 +308,4 @@ rtgconfig.common.trees.treesCanGenerateOnSand.tooltip=Set this to FALSE to preve
 rtgconfig.common.trees.shrubsBelowSurface=Shrubs Below Surface
 rtgconfig.common.trees.shrubsBelowSurface.tooltip=Set this to FALSE to prevent shrub trunks from generating below the surface.
 rtgconfig.common.trees.barkCoveredLogs=Bark Covered Logs
-rtgconfig.common.trees.barkCoveredLogs.tooltip=Set this to FALSE to prevent the trunks of RTG trees from using the 'all-bark' texture model.\nFor more information, visit http://minecraft.gamepedia.com/Wood#Block_data
+rtgconfig.common.trees.barkCoveredLogs.tooltip=Set this to FALSE to prevent the trunks of RTG trees from using the 'all-bark' texture model.\nFor more information, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Wood


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.